### PR TITLE
Feature/web 20530

### DIFF
--- a/examples/scripts/example08-sortable-cols.js
+++ b/examples/scripts/example08-sortable-cols.js
@@ -30,6 +30,17 @@ var rowGetter = function(i){
   return _rows[i];
 };
 
+var dateSort = function(sortColumn, sortDirection, rows){
+  var comparer = function(a, b) {
+    if(sortDirection === 'ASC'){
+      return (a[sortColumn] < b[sortColumn]) ? 1 : -1;
+    }else if(sortDirection === 'DESC'){
+      return (a[sortColumn] > b[sortColumn]) ? 1 : -1;
+    }
+  }
+  return rows.sort(comparer);
+};
+
 //Columns definition
 var columns = [
 {
@@ -59,8 +70,9 @@ var columns = [
 },
 {
   key: 'startDate',
-  name: 'Start Date',
-  sortable : true
+  name: 'Start date',
+  sortable : true,
+  sortingFunction: dateSort
 },
 {
   key: 'completeDate',
@@ -68,6 +80,20 @@ var columns = [
   sortable : true
 }
 ]
+
+
+var PropertyGroupRow = React.createClass({
+    getDefaultProps : function() {
+      return {name: 'priority'};
+    },
+
+  render:function(){
+    return(
+      <div className="property-group" ><b>{this.props.row.priority}</b></div>
+    )
+  }
+
+});
 
 var Example = React.createClass({
 
@@ -102,7 +128,7 @@ var Example = React.createClass({
         rowGetter={this.rowGetter}
         rowsCount={this.state.rows.length}
         minHeight={500}
-        groupOnAttribute={["priority"]}
+        groupOnAttribute={[PropertyGroupRow]}
         onRowUpdated={this.handleRowUpdated}/>
     )
   }

--- a/examples/scripts/example08-sortable-cols.js
+++ b/examples/scripts/example08-sortable-cols.js
@@ -69,11 +69,10 @@ var columns = [
 }
 ]
 
-
 var Example = React.createClass({
 
   getInitialState : function(){
-    var originalRows = createRows(1000);
+    var originalRows = createRows(100);
     var rows = originalRows.slice(0);
     //store the original rows array, and make a copy that can be used for modifying eg.filtering, sorting
     return {originalRows : originalRows, rows : rows};
@@ -96,14 +95,15 @@ var Example = React.createClass({
   },
 
   render:function(){
+
     return(
       <ReactDataGrid
-        onGridSort={this.handleGridSort}
         columns={columns}
         rowGetter={this.rowGetter}
         rowsCount={this.state.rows.length}
         minHeight={500}
-        onRowUpdated={this.handleRowUpdated} />
+        groupOnAttribute={["priority"]}
+        onRowUpdated={this.handleRowUpdated}/>
     )
   }
 

--- a/examples/scripts/example08-sortable-cols.js
+++ b/examples/scripts/example08-sortable-cols.js
@@ -121,7 +121,6 @@ var Example = React.createClass({
   },
 
   render:function(){
-
     return(
       <ReactDataGrid
         columns={columns}

--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -34,8 +34,8 @@ var Canvas = React.createClass({
   },
 
   render(): ?ReactElement {
-    var displayStart = this.state.displayStart;
-    var displayEnd = this.state.displayEnd;
+    var displayStart = this.props.displayStart;
+    var displayEnd = this.props.displayEnd;
     var rowHeight = this.props.rowHeight;
     var length = this.props.rowsCount;
     var groupOnAttribute = this.props.groupOnAttribute;
@@ -77,6 +77,8 @@ var Canvas = React.createClass({
       transform: 'translate3d(0, 0, 0)'
     };
 
+    var groupedRows = this.props.groupedRows;
+
     return (
       <div
         style={style}
@@ -91,9 +93,10 @@ var Canvas = React.createClass({
 
   renderGroupedRows(groupedRows) {
     if ((typeof groupedRows === 'object') && (groupedRows instanceof Array == false)){
+      var that = this;
       return (
         Object.keys(groupedRows)
-          .sort(function (l,r) { 
+          .sort(function (l,r) {
             return l.localeCompare(r);
           }).map(function(groupName){
           return (<div>
@@ -104,10 +107,23 @@ var Canvas = React.createClass({
             />
             {this.renderGroupedRows(groupedRows[groupName]['rows'])}
           </div>)
-        }, this)
+        },this)
       );
     } else {
-      return groupedRows;
+      var displayStart = this.props.displayStart;
+      var rowHeight = this.props.rowHeight;
+      return groupedRows.map((row, idx) =>
+        this.renderRow({
+          key: displayStart + idx,
+          ref: idx,
+          idx: displayStart + idx,
+          row: row,
+          height: rowHeight,
+          columns: this.props.columns,
+          isSelected : this.isRowSelected(displayStart + idx),
+          expandedRows : this.props.expandedRows,
+          cellMetaData : this.props.cellMetaData
+        }));
     }
   },
 
@@ -153,8 +169,9 @@ var Canvas = React.createClass({
 
     Object.keys(groupedRows).map(function(groupName){
       groupedRows[groupName]['rows'] = this.groupByRowAttributes(attributes, groupedRows[groupName]['rows']);
+      //TODO sort each group here
     }, this);
-
+    var x;
     return groupedRows;
   },
 

--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -95,7 +95,7 @@ var Canvas = React.createClass({
         });
         break;
       case 'group':
-        return this.renderGroupRow({name: row.name});
+        return this.renderGroupRow({displayElement: row.displayElement});
     }
   },
 
@@ -113,7 +113,7 @@ var Canvas = React.createClass({
     return <RowContainer
       height={this.props.rowHeight}
       width={this.props.width}
-      renderer={props.name}
+      renderer={props.displayElement}
     />
   },
 

--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -34,13 +34,13 @@ var Canvas = React.createClass({
   },
 
   render(): ?ReactElement {
-    var displayStart = this.props.displayStart;
-    var displayEnd = this.props.displayEnd;
+    var displayStart = this.state.displayStart;
+    var displayEnd = this.state.displayEnd;
     var rowHeight = this.props.rowHeight;
     var length = this.props.rowsCount;
     var groupOnAttribute = this.props.groupOnAttribute;
-
-    var rows = this.props.getRows(displayStart, displayEnd)
+console.log('rendering canvas');
+    var rows = this.props.groupedRows.slice(displayStart, displayEnd)
         .map((row,idx) => this.renderRow(row,idx));
 
     this._currentRowsLength = rows.length;
@@ -184,6 +184,7 @@ var Canvas = React.createClass({
                         || nextProps.rowsCount !== this.props.rowsCount
                         || nextProps.rowHeight !== this.props.rowHeight
                         || nextProps.columns !== this.props.columns
+                        || nextProps.groupedRows !== this.props.groupedRows
                         || nextProps.width !== this.props.width
                         || nextProps.cellMetaData !== this.props.cellMetaData
                         || !shallowEqual(nextProps.style, this.props.style);
@@ -208,19 +209,6 @@ var Canvas = React.createClass({
     if (this._currentRowsRange !== {start: 0, end: 0}) {
       this.props.onRows(this._currentRowsRange);
       this._currentRowsRange = {start: 0, end: 0};
-    }
-  },
-
-  getRows(displayStart: number, displayEnd: number): Array<any> {
-    this._currentRowsRange = {start: displayStart, end: displayEnd};
-    if (Array.isArray(this.props.rowGetter)) {
-      return this.props.rowGetter.slice(displayStart, displayEnd);
-    } else {
-      var rows = [];
-      for (var i = displayStart; i < displayEnd; i++){
-        rows.push(this.props.rowGetter(i));
-      }
-      return rows;
     }
   },
 

--- a/src/Canvas.js
+++ b/src/Canvas.js
@@ -39,7 +39,6 @@ var Canvas = React.createClass({
     var rowHeight = this.props.rowHeight;
     var length = this.props.rowsCount;
     var groupOnAttribute = this.props.groupOnAttribute;
-console.log('rendering canvas');
     var rows = this.props.groupedRows.slice(displayStart, displayEnd)
         .map((row,idx) => this.renderRow(row,idx));
 
@@ -135,7 +134,7 @@ console.log('rendering canvas');
   },
 
   isRowSelected(rowIdx: number): boolean{
-   return this.props.selectedRows && this.props.selectedRows[rowIdx] === true;
+    return this.props.selectedRows && this.props.selectedRows[rowIdx] === true;
   },
 
   _currentRowsLength : 0,

--- a/src/Grid.js
+++ b/src/Grid.js
@@ -85,6 +85,10 @@ var Grid = React.createClass({
               rowOffsetHeight={this.props.rowOffsetHeight || this.props.rowHeight * headerRows.length}
               minHeight={this.props.minHeight}
               groupOnAttribute={this.props.groupOnAttribute}
+              sortColumn={this.props.sortColumn}
+              sortDirection={this.props.sortDirection}
+              columns={this.props.columnMetrics.columns}
+              onGridSort={this.props.onGridSort}
               />
           </div>
       </div>

--- a/src/Viewport.js
+++ b/src/Viewport.js
@@ -70,10 +70,7 @@ var Viewport = React.createClass({
     var groupedRows = this.groupByRowAttributes(this.props.groupOnAttribute, allRows);
     var rows = this.flattenGroupedRows(groupedRows, []);
     this.setState({rows: rows});
-  },
-
-  getRows: function(start, end) {
-    return this.state.rows.slice(start, end);
+    console.log('new rows state');
   },
 
   flattenGroupedRows: function(groupedRows, flattenedRows) {
@@ -168,7 +165,6 @@ var Viewport = React.createClass({
           ref="canvas"
           totalWidth={this.props.totalWidth}
           width={this.props.columnMetrics.width}
-          getRows={this.getRows}
           rowsCount={this.props.rowsCount}
           selectedRows={this.props.selectedRows}
           expandedRows={this.props.expandedRows}

--- a/src/Viewport.js
+++ b/src/Viewport.js
@@ -55,7 +55,7 @@ var Viewport = React.createClass({
 
   getInitialState: function() {
       return {
-        groupedRows: [],
+        rows: [],
       };
   },
 
@@ -64,18 +64,28 @@ var Viewport = React.createClass({
   },
 
   getGroupedRows: function() {
-    debugger;
     var allRows = this.getAllRows();
     var groupedRows = this.groupByRowAttributes(this.props.groupOnAttribute, allRows);
-    this.setState({groupedRows: groupedRows});
+    var rows = this.flattenGroupedRows(groupedRows, []);
+    this.setState({rows: rows});
+  },
+
+  flattenGroupedRows: function(groupedRows, flattenedRows) {
+    if ((typeof groupedRows === 'object') && (groupedRows instanceof Array == false)){
+        Object.keys(groupedRows)
+          .sort(function (l,r) {
+            return l.localeCompare(r);
+          }).map(function(groupName){
+            flattenedRows.push({type: 'group', name: groupName});
+            this.flattenGroupedRows(groupedRows[groupName]['rows'], flattenedRows);
+        },this);
+      return flattenedRows;
+    } else {
+      return groupedRows.forEach((r) => flattenedRows.push({type:'single', data: r}));
+    }
   },
 
   sortRows: function(sortColumn, sortDirection , rows){
-    // if(!sortColumn) { return function(rows) {return rows;}}
-    // var column = $.grep(this.props.columns, function(e){ return e.key == sortColumn; })[0];
-    // var genericSort = column.hasOwnProperty("sortingFunction") ? column.sortingFunction : this.props.onGridSort;
-    // var sort = genericSort.bind(null, sortColumn, sortDirection);
-    // return sort;
     if(!sortColumn || !rows) return rows;
     var column = $.grep(this.props.columns, function(e){ return e.key == sortColumn; })[0];
     var onSort = column.hasOwnProperty("sortingFunction") ? column.sortingFunction : this.props.onGridSort;
@@ -172,7 +182,7 @@ var Viewport = React.createClass({
           onRows={this.props.onRows}
           sortRows={this.sortRows(this.props.sortColumn, this.props.sortDirection)}
           groupOnAttribute={this.props.groupOnAttribute}
-          groupedRows={this.state.groupedRows}
+          groupedRows={this.state.rows}
           />
       </div>
     );

--- a/src/Viewport.js
+++ b/src/Viewport.js
@@ -70,6 +70,10 @@ var Viewport = React.createClass({
     this.setState({rows: rows});
   },
 
+  getRows: function(start, end) {
+    return this.state.rows.slice(start, end);
+  },
+
   flattenGroupedRows: function(groupedRows, flattenedRows) {
     if ((typeof groupedRows === 'object') && (groupedRows instanceof Array == false)){
         Object.keys(groupedRows)
@@ -91,8 +95,6 @@ var Viewport = React.createClass({
     var onSort = column.hasOwnProperty("sortingFunction") ? column.sortingFunction : this.props.onGridSort;
     return onSort(sortColumn, sortDirection, rows);
   },
-
-
 
   groupByRowAttributes: function(attrs: any, rows: any) {
     if ((attrs instanceof Array == false) || !attrs.length > 0) {
@@ -165,7 +167,7 @@ var Viewport = React.createClass({
           ref="canvas"
           totalWidth={this.props.totalWidth}
           width={this.props.columnMetrics.width}
-          rowGetter={this.props.rowGetter}
+          getRows={this.getRows}
           rowsCount={this.props.rowsCount}
           selectedRows={this.props.selectedRows}
           expandedRows={this.props.expandedRows}

--- a/src/Viewport.js
+++ b/src/Viewport.js
@@ -37,7 +37,7 @@ var Viewport = React.createClass({
     var defaultGridSort = function(sortColumn, sortDirection, rows){
       var comparer = function(a, b) {
         if (a[sortColumn]==null) return 1
-        if (b[sortColumn]==null) return 0
+        if (b[sortColumn]==null) return -1
         if(sortDirection === 'ASC'){
           return (a[sortColumn] > b[sortColumn]) ? 1 : -1;
         }else if(sortDirection === 'DESC'){

--- a/src/Viewport.js
+++ b/src/Viewport.js
@@ -59,10 +59,9 @@ var Viewport = React.createClass({
       };
   },
 
-  componentDidUpdate(prevProps, prevState) {
+  componentDidUpdate: function(prevProps, prevState) {
     if(prevProps.sortColumn != this.props.sortColumn || prevProps.sortDirection != this.props.sortDirection) {
       this.getGroupedRows();
-      console.log('updating');
     }
   },
 
@@ -83,7 +82,7 @@ var Viewport = React.createClass({
           .sort(function (l,r) {
             return l.localeCompare(r);
           }).map(function(groupName){
-            flattenedRows.push({type: 'group', name: groupName});
+            flattenedRows.push({type: 'group', displayElement: groupedRows[groupName].groupHeaderDisplay});
             this.flattenGroupedRows(groupedRows[groupName]['rows'], flattenedRows);
         },this);
       return flattenedRows;
@@ -120,10 +119,10 @@ var Viewport = React.createClass({
           break;
         case 'string':
           attribute_name = row[attribute];
-          attribute_value = React.createElement('div', {className: 'groupName'}, attribute_name.toString());
+          attribute_value = React.createElement('div', {className: 'groupName', style: {padding: '6px', fontSize: '16px', fontWeight: 'bold'}}, attribute_name.toString());
           break;
         default:
-          if (row[attribulite] == 'undefined') return;
+          if (row[attribute] == 'undefined') return;
       }
 
       if (typeof(groupedRows[attribute_name]) === "undefined") groupedRows[attribute_name] = {groupHeaderDisplay: attribute_value, rows: []};
@@ -132,7 +131,6 @@ var Viewport = React.createClass({
 
     Object.keys(groupedRows).map(function(groupName){
       groupedRows[groupName]['rows'] = this.groupByRowAttributes(attributes, groupedRows[groupName]['rows']);
-      //TODO sort each group here
     }, this);
 
     return groupedRows;

--- a/src/Viewport.js
+++ b/src/Viewport.js
@@ -59,8 +59,11 @@ var Viewport = React.createClass({
       };
   },
 
-  componentWillReceiveProps: function(nextProps) {
-
+  componentDidUpdate(prevProps, prevState) {
+    if(prevProps.sortColumn != this.props.sortColumn || prevProps.sortDirection != this.props.sortDirection) {
+      this.getGroupedRows();
+      console.log('updating');
+    }
   },
 
   getGroupedRows: function() {

--- a/src/Viewport.js
+++ b/src/Viewport.js
@@ -36,6 +36,8 @@ var Viewport = React.createClass({
   getDefaultProps: function() {
     var defaultGridSort = function(sortColumn, sortDirection, rows){
       var comparer = function(a, b) {
+        if (a[sortColumn]==null) return 1
+        if (b[sortColumn]==null) return 0
         if(sortDirection === 'ASC'){
           return (a[sortColumn] > b[sortColumn]) ? 1 : -1;
         }else if(sortDirection === 'DESC'){
@@ -166,7 +168,7 @@ var Viewport = React.createClass({
           ref="canvas"
           totalWidth={this.props.totalWidth}
           width={this.props.columnMetrics.width}
-          rowsCount={this.props.rowsCount}
+          rowsCount={this.state.rows.length}
           selectedRows={this.props.selectedRows}
           expandedRows={this.props.expandedRows}
           columns={this.props.columnMetrics.columns}
@@ -174,7 +176,7 @@ var Viewport = React.createClass({
           visibleStart={this.state.visibleStart}
           visibleEnd={this.state.visibleEnd}
           displayStart={this.state.displayStart}
-          displayEnd={this.state.displayEnd}
+          displayEnd={Math.max(this.state.displayEnd, this.state.rows.length)}
           cellMetaData={this.props.cellMetaData}
           height={this.state.height}
           rowHeight={this.props.rowHeight}

--- a/src/Viewport.js
+++ b/src/Viewport.js
@@ -34,17 +34,10 @@ var Viewport = React.createClass({
   },
 
   getDefaultProps: function() {
-    var defaultGridSort = function(sortColumn, sortDirection, rows){
-      var comparer = function(a, b) {
-        if (a[sortColumn]==null) return 1
-        if (b[sortColumn]==null) return -1
-        if(sortDirection === 'ASC'){
-          return (a[sortColumn] > b[sortColumn]) ? 1 : -1;
-        }else if(sortDirection === 'DESC'){
-          return (a[sortColumn] < b[sortColumn]) ? 1 : -1;
-        }
-      }
-      return rows.sort(comparer);
+    var defaultGridSort = function(a, b) {
+      if (a==null) return 1;
+      if (b==null) return -1;
+      return (a > b) ? 1 : -1;
     };
     return {
       onGridSort: defaultGridSort
@@ -95,7 +88,16 @@ var Viewport = React.createClass({
     if(!sortColumn || !rows) return rows;
     var column = $.grep(this.props.columns, function(e){ return e.key == sortColumn; })[0];
     var onSort = column.hasOwnProperty("sortingFunction") ? column.sortingFunction : this.props.onGridSort;
-    return onSort(sortColumn, sortDirection, rows);
+
+    var that = this;
+    var comparer = function(a, b) {
+      if(sortDirection === 'ASC'){
+        return that.props.onGridSort(a[sortColumn], b[sortColumn]);
+      }else if(sortDirection === 'DESC'){
+        return that.props.onGridSort(b[sortColumn], a[sortColumn]);
+      }
+    }
+    return rows.sort(comparer);
   },
 
   groupByRowAttributes: function(attrs: any, rows: any) {

--- a/src/Viewport.js
+++ b/src/Viewport.js
@@ -60,7 +60,9 @@ var Viewport = React.createClass({
   },
 
   componentDidUpdate: function(prevProps, prevState) {
-    if(prevProps.sortColumn != this.props.sortColumn || prevProps.sortDirection != this.props.sortDirection) {
+    if(prevProps.sortColumn != this.props.sortColumn
+      || prevProps.sortDirection != this.props.sortDirection
+      || prevProps.rowGetter != this.props.rowGetter) {
       this.getGroupedRows();
     }
   },
@@ -70,7 +72,6 @@ var Viewport = React.createClass({
     var groupedRows = this.groupByRowAttributes(this.props.groupOnAttribute, allRows);
     var rows = this.flattenGroupedRows(groupedRows, []);
     this.setState({rows: rows});
-    console.log('new rows state');
   },
 
   flattenGroupedRows: function(groupedRows, flattenedRows) {

--- a/src/addons/grids/ReactDataGrid.js
+++ b/src/addons/grids/ReactDataGrid.js
@@ -65,7 +65,7 @@ var ReactDataGrid = React.createClass({
     width: React.PropTypes.number,
     enableRowSelect: React.PropTypes.bool,
     onRowUpdated:React.PropTypes.func,
-    rowGetter: React.PropTypes.func.isRequired,
+    rowGetter: PropTypes.oneOfType([PropTypes.array, PropTypes.func]).isRequired,
     rowsCount : React.PropTypes.number.isRequired,
     toolbar:React.PropTypes.element,
     enableCellSelect : React.PropTypes.bool,

--- a/src/addons/grids/ReactDataGrid.js
+++ b/src/addons/grids/ReactDataGrid.js
@@ -476,9 +476,7 @@ var ReactDataGrid = React.createClass({
   },
 
   handleSort: function(columnKey: string, direction: SortType) {
-    this.setState({sortDirection: direction, sortColumn: columnKey}, function(){
-      //this.props.onGridSort(columnKey, direction);
-    });
+    this.setState({sortDirection: direction, sortColumn: columnKey});
   },
 
   copyPasteEnabled: function(): boolean {

--- a/src/addons/grids/ReactDataGrid.js
+++ b/src/addons/grids/ReactDataGrid.js
@@ -477,7 +477,7 @@ var ReactDataGrid = React.createClass({
 
   handleSort: function(columnKey: string, direction: SortType) {
     this.setState({sortDirection: direction, sortColumn: columnKey}, function(){
-      this.props.onGridSort(columnKey, direction);
+      //this.props.onGridSort(columnKey, direction);
     });
   },
 


### PR DESCRIPTION
Allow sorting of rows within a group, and fix grouping. Also allow custom sorting functions on a per column basis

This involved a refactor of component concerns. the `Viewport` component now handles all manipulation of row data, and passes it to `Canvas`, which wraps the rows in appropriate react components. 

Previously, grouping was handled by the `Canvas` component. As the `Canvas` component only recieves a collection of currently visible rows, this would cause the rows to erratically regroup when scrolling.

Also changed was the sorting example page. It now showcases the new features.